### PR TITLE
Delete payment type

### DIFF
--- a/bangazonllc/settings.py
+++ b/bangazonllc/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'corsheaders',
     'ecommerceapi',
+    'safedelete'
 ]
 
 REST_FRAMEWORK = {

--- a/ecommerceapi/models/payment_type.py
+++ b/ecommerceapi/models/payment_type.py
@@ -1,9 +1,11 @@
 """This file contains the Model for PaymentType"""
 
 from django.db import models
+from safedelete.models import SafeDeleteModel
+from safedelete.models import SOFT_DELETE
 from .customer import Customer
 
-class PaymentType(models.Model):
+class PaymentType(SafeDeleteModel):
 
     """This class defines the payment types for the Bangazon eCommerce application"""
 
@@ -12,6 +14,7 @@ class PaymentType(models.Model):
     expiration_date = models.DateField(blank=True, null=True)
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING)
     created_at = models.DateField(blank=True, null=True, auto_now=True)
+    _safedelete_policy = SOFT_DELETE
 
     class Meta:
         verbose_name = ("Payment_Type")

--- a/ecommerceapi/views/payment_type.py
+++ b/ecommerceapi/views/payment_type.py
@@ -30,6 +30,20 @@ class PaymentTypes(ViewSet):
     View set class for payment types.
     """
 
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single payment type
+        Returns:
+            Response -- JSON serialized product instance
+        """
+
+        try:
+            payment_type = PaymentType.objects.get(pk=pk)
+            customer = Customer.objects.get(user=request.user)
+            serializer = PaymentTypeSerializer(payment_type, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
     def create(self, request):
         '''Handle POST operations
 

--- a/ecommerceapi/views/payment_type.py
+++ b/ecommerceapi/views/payment_type.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
+from rest_framework import status
 from ecommerceapi.models import PaymentType, Customer
 
 class PaymentTypeSerializer(serializers.HyperlinkedModelSerializer):
@@ -64,6 +65,26 @@ class PaymentTypes(ViewSet):
         serializer = PaymentTypeSerializer(new_pay_type, context={'request': request})
 
         return Response(serializer.data)
+
+    def destroy(self, request, pk=None):
+        '''
+        Handle DELETE requests for a payment type. Django safedelete is active for this model.
+        
+        Returns:
+            Response -- 200, 404, or 500 status code
+        '''
+        try:
+            payment_type = PaymentType.objects.get(pk=pk)
+
+            payment_type.delete()
+
+            return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+        except PaymentType.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def list(self, request):
         '''Handle GET operations


### PR DESCRIPTION
# Description
Payment types can now be safely deleted. It's a soft delete so orders associated with the payment id should still be searchable

Fixes #8 (https://github.com/nss-cohort-40/bangazon-ecommerce-api-lumberjacks-back/issues/8)
## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
• `pip install django-safedelete`
• `python manage.py makemigrations ecommerceapi`
• `python manage.py migrate`
• Try deleting a payment method that is connected to a completed order from the profile page.
• Check database to ensure payment type has a delete date attribute in db

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
